### PR TITLE
Class to calculate Net Operational Value (NOV)

### DIFF
--- a/cerf/nov.py
+++ b/cerf/nov.py
@@ -2,26 +2,7 @@ import calendar
 
 
 class NetOperationalValue:
-    """Calculate Net Operational Value (NOV) in ($ / yr) per grid cell as the following:
-
-        NOV ($ / yr) = Generation (MWh / yr) *
-                            [ Locational Marginal Price ($ / MWh) - Operating Costs ($ / MWh) ] *
-                            Levelization Factor
-                where, Operating Costs ($ / MWh) = Heat Rate (Btu / kWh) *
-                                                    Fuel Price ($ / MBtu) +
-                                                    Variable O&M ($ / MWh) +
-                                                    Carbon Price ($ / ton) *
-                                                    Carbon Fuel Content (tons / Btu) *
-                                                    Heat Rate (Btu / kWh) *
-                                                    (1 - Carbon Capture Rate (%))
-                and, Levelization Factor = k * (1 - k**n) * (Annuity Factor / (1 - k))
-                    where, k = (1 + l) / (1 + d)
-                            l = real annual growth rate (%)
-                            d = real annual discount rate (%)
-                    and, Annuity factor is (d(1 + d)**n) / ((1 + d)**n - 1)
-                        where, d = real annual discount rate (%)
-                                n = asset lifetime (years)
-
+    """Calculate Net Operational Value (NOV) in ($ / yr) per grid cell for all technologies.
 
     :param discount_rate:                   The time value of money in real terms.
                                             Units:  fraction
@@ -62,7 +43,7 @@ class NetOperationalValue:
     :type heat_rate:                        float
 
     :param fuel_price:                      Cost of fuel per unit.
-                                            Units:  from GCAM ($2010/GJ) gets converted to ($/MBtu)
+                                            Units:  from GCAM ($/GJ) gets converted to ($/MBtu)
     :type fuel_price:                       float
 
     :param carbon_tax:                      The fee imposed on the burning of carbon-based fuels.
@@ -80,7 +61,7 @@ class NetOperationalValue:
     :param lmp_arr:                         Locational Marginal Price (LMP) per grid cell for each technology in a
                                             multi-dimensional array where the shape is [tech_id, xcoord, ycoord].
                                             Units:  $/MWh
-    :type lmp_arr:                          numpy.ndarray
+    :type lmp_arr:                          ndarray
 
     """
 
@@ -105,6 +86,7 @@ class NetOperationalValue:
         self.variable_om = variable_om
         self.heat_rate = heat_rate
         self.carbon_tax = carbon_tax
+        self.carbon_capture_rate = carbon_capture_rate
         self.lmp_arr = lmp_arr
 
         # create conversions
@@ -129,7 +111,7 @@ class NetOperationalValue:
 
     @staticmethod
     def convert_fuel_price(fuel_price):
-        """Convert fuel price from units $2010/GJ to $/MBtu"""
+        """Convert fuel price from units $/GJ to $/MBtu"""
 
         return fuel_price * NetOperationalValue.FUEL_PRICE_CONVERSION_FACTOR
 

--- a/cerf/nov.py
+++ b/cerf/nov.py
@@ -1,126 +1,185 @@
-import numpy as np
+import calendar
 
 
 class NetOperationalValue:
-    """Calculate Net Operating Value (NOV) in ($ / yr) per grid cell as the following:
+    """Calculate Net Operational Value (NOV) in ($ / yr) per grid cell as the following:
 
-    NOV ($ / yr) = Generation (MWh / yr) *
-                        [ Locational Marginal Price ($ / MWh) - Operating Costs ($ / MWh) ] *
-                        Levelization Factor
-            where, Operating Costs ($ / MWh) = Heat Rate (Btu / kWh) *
-                                                Fuel Price ($ / MBtu) +
-                                                Variable O&M ($ / MWh) +
-                                                Carbon Price ($ / ton) *
-                                                Carbon Fuel Content (tons / Btu) *
-                                                Heat Rate (Btu / kWh) *
-                                                (1 - Carbon Capture Rate (%))
-            and, Levelization Factor = k * (1 - k**n) * (Annuity Factor / (1 - k))
-                where, k = (1 + l) / (1 + d)
-                        l = real annual growth rate (%)
-                        d = real annual discount rate (%)
-                and, Annuity factor is (d(1 + d)**n) / ((1 + d)**n - 1)
-                    where, d = real annual discount rate (%)
-                            n = asset lifetime (years)
+        NOV ($ / yr) = Generation (MWh / yr) *
+                            [ Locational Marginal Price ($ / MWh) - Operating Costs ($ / MWh) ] *
+                            Levelization Factor
+                where, Operating Costs ($ / MWh) = Heat Rate (Btu / kWh) *
+                                                    Fuel Price ($ / MBtu) +
+                                                    Variable O&M ($ / MWh) +
+                                                    Carbon Price ($ / ton) *
+                                                    Carbon Fuel Content (tons / Btu) *
+                                                    Heat Rate (Btu / kWh) *
+                                                    (1 - Carbon Capture Rate (%))
+                and, Levelization Factor = k * (1 - k**n) * (Annuity Factor / (1 - k))
+                    where, k = (1 + l) / (1 + d)
+                            l = real annual growth rate (%)
+                            d = real annual discount rate (%)
+                    and, Annuity factor is (d(1 + d)**n) / ((1 + d)**n - 1)
+                        where, d = real annual discount rate (%)
+                                n = asset lifetime (years)
 
 
-    :param discount_rate:                   The time value of money in real terms. Fraction.
+    :param discount_rate:                   The time value of money in real terms.
+                                            Units:  fraction
     :type discount_rate:                    float
 
-    :param lifetime:                        Years of the expected technology plant lifetime.  Years.
+    :param lifetime:                        Years of the expected technology plant lifetime.
+                                            Units:  years
     :type lifetime:                         int
 
-    :param unit_size:                       The size of the expected power plant in MW
+    :param unit_size:                       The size of the expected power plant.
+                                            Units:  megawatt
     :type unit_size:                        int
 
-    :param cap_fact:                        Capacity factor defined as average annual power generated divided by the
+    :param capacity_factor:                 Capacity factor defined as average annual power generated divided by the
                                             potential output if the plant operated at its rated capacity for a year.
-    :type cap_fact:                         float
+                                            Units:  fraction
+    :type capacity_factor:                  float
 
-    :param variable_om_esc:                 Escalation factor of variable cost.  Fraction.
-    :type variable_om_esc:                  float
+    :param variable_cost_esc_rate:          Escalation rate of variable cost.
+                                            Units:  fraction
+    :type variable_cost_esc_rate:           float
 
-    :param fuel_esc:                        Fuel price escalation factor. Fraction.
-    :type fuel_esc:                         float
+    :param fuel_esc_rate:                   Escalation rate of fuel.
+                                            Units:  fraction
+    :type fuel_esc_rate:                    float
 
-    :param carbon_esc:                      The annual escalation rate for carbon tax.
-    :type carbon_esc:                       float
+    :param carbon_esc_rate:                 Escalation rate of carbon.
+                                            Units:  fraction
+    :type carbon_esc_rate:                  float
 
-    :param variable_om:                     Variable operation and maintenance costs of yearly capacity use in $/MWh
+    :param variable_om:                     Variable operation and maintenance costs of yearly capacity use.
+                                            Units:  $/MWh
     :type variable_om:                      float
 
     :param heat_rate:                       Amount of energy used by a power plant to generate one kilowatt-hour of
-                                            electricity in Btu/kWh
+                                            electricity.
+                                            Units:  Btu/kWh
     :type heat_rate:                        float
 
-    :param fuel_price:                      Cost of fuel per unit in $/MBtu.
+    :param fuel_price:                      Cost of fuel per unit.
+                                            Units:  from GCAM ($2010/GJ) gets converted to ($/MBtu)
     :type fuel_price:                       float
 
-    :param carbon_tax:                      The fee imposed on the burning of carbon-based fuels in $/ton
+    :param carbon_tax:                      The fee imposed on the burning of carbon-based fuels.
+                                            Units:  $/ton
     :type carbon_tax:                       float
 
-    :param carbon_capture:                  Rate of carbon capture.
-    :type carbon_capture:                   float
+    :param carbon_capture_rate:             Rate of carbon capture.
+                                            Units:  fraction
+    :type carbon_capture_rate:              float
 
-    :param fuel_co2:                        CO2 content of the fuel and the heat rate of the technology in Tons/MWh
-    :type fuel_co2:                         float
+    :param fuel_co2_content:                CO2 content of the fuel and the heat rate of the technology.
+                                            Units:  from GCAM (tons/MWh) gets converted to (tons/Btu)
+    :type fuel_co2_content:                 float
 
     :param lmp_arr:                         Locational Marginal Price (LMP) per grid cell for each technology in a
-                                            multi-dimensional array where the shape is [tech_id, xcoord, ycoord]
-    :type lmp_arr:                          NumPy array as dtype np.int
+                                            multi-dimensional array where the shape is [tech_id, xcoord, ycoord].
+                                            Units:  $/MWh
+    :type lmp_arr:                          numpy.ndarray
 
     """
 
-    def __init__(self, discount_rate, lifetime, unit_size, capacity_factor, variable_om_esc_rate,
-                 fuel_esc_rate, carbon_esc_rate, variable_om, heat_rate, fuel_price, carbon_tax,
-                 carbon_capture_rate, fuel_co2_content, lmp_arr):
+    # constants for conversion
+    FUEL_CO2_CONTENT_CONVERSION_FACTOR = 0.000000293071
+    FUEL_PRICE_CONVERSION_FACTOR = 1.055056
+    HOURS_PER_YEAR_NONLEAP = 8760
+    HOURS_PER_YEAR_LEAP = 8784
 
+    def __init__(self, discount_rate, lifetime, unit_size, capacity_factor, variable_cost_esc_rate,
+                 fuel_esc_rate, carbon_esc_rate, variable_om, heat_rate, fuel_price, carbon_tax,
+                 carbon_capture_rate, fuel_co2_content, lmp_arr, target_year):
+
+        # assign class attributes
         self.discount_rate = discount_rate
         self.lifetime = lifetime
         self.unit_size = unit_size
-        self.cap_fact = capacity_factor
-        self.variable_om_esc = variable_om_esc_rate
+        self.capacity_factor = capacity_factor
+        self.variable_cost_esc = variable_cost_esc_rate
         self.fuel_esc = fuel_esc_rate
         self.carbon_esc = carbon_esc_rate
         self.variable_om = variable_om
         self.heat_rate = heat_rate
-        self.fuel_price = fuel_price
         self.carbon_tax = carbon_tax
-        self.carbon_capture = carbon_capture_rate
-        self.fuel_co2 = fuel_co2_content
         self.lmp_arr = lmp_arr
+
+        # create conversions
+        self.fuel_price = self.convert_fuel_price(fuel_price)
+        self.fuel_co2_content = self.convert_fuel_co2_content(fuel_co2_content)
+        self.hours_per_year = self.assign_hours_per_year(target_year)
+
+        # calculate annuity factor
+        self.annuity_factor = self.calc_annuity_factor()
+
+        # calculate levelizing factor for variable OM
+        self.lf_vom = self.calc_levelization_factor_vom()
+
+        # calculate levelizing factor for fuel
+        self.lf_fuel = self.calc_levelization_factor_fuel()
+
+        # calculate levelizing factor for carbon
+        self.lf_carbon = self.calc_levelization_factor_carbon()
+
+        # calculate NOV
+        self.nov = self.calc_nov()
+
+    @staticmethod
+    def convert_fuel_price(fuel_price):
+        """Convert fuel price from units $2010/GJ to $/MBtu"""
+
+        return fuel_price * NetOperationalValue.FUEL_PRICE_CONVERSION_FACTOR
+
+    @staticmethod
+    def convert_fuel_co2_content(fuel_co2_content):
+        """Convert fuel CO2 content from units tons/MWh to tons/Btu"""
+
+        return fuel_co2_content * NetOperationalValue.FUEL_CO2_CONTENT_CONVERSION_FACTOR
+
+    @classmethod
+    def assign_hours_per_year(cls, target_year):
+        """Assign the hours per year based on whether or not the target year is a leap year."""
+
+        if calendar.isleap(target_year):
+            return cls.HOURS_PER_YEAR_LEAP
+        else:
+            return cls.HOURS_PER_YEAR_NONLEAP
 
     def calc_annuity_factor(self):
         """Calculate annuity factor."""
-        fx = np.power(1.0 + self.discount_rate, self.lifetime)
+
+        fx = pow(1.0 + self.discount_rate, self.lifetime)
         return self.discount_rate * fx / (fx - 1.0)
 
-    def calc_lf_lmp(self):
-        """Calculate the levelizing factor for LMP."""
-        k = (1.0 + self.lmp_arr) / (1.0 + self.discount_rate)
-        return k * (1.0 - np.power(k, self.lifetime)) * self.calc_annuity_factor() / (1.0 - k)
-
-    def calc_lf_vom(self):
+    def calc_levelization_factor_vom(self):
         """Calculate the levelizing factor for variable OM."""
-        k = (1.0 + self.variable_om_esc) / (1.0 + self.discount_rate)
-        return k * (1.0 - np.power(k, self.lifetime)) * self.calc_annuity_factor() / (1.0 - k)
 
-    def calc_lf_fuel(self):
+        k = (1.0 + self.variable_cost_esc) / (1.0 + self.discount_rate)
+        return k * (1.0 - pow(k, self.lifetime)) * self.annuity_factor / (1.0 - k)
+
+    def calc_levelization_factor_fuel(self):
         """Calculate the levelizing factor for fuel."""
-        k = (1.0 + self.fuel_esc) / (1.0 + self.discount_rate)
-        return k * (1.0 - np.power(k, self.lifetime)) * self.calc_annuity_factor() / (1.0 - k)
 
-    def calc_lf_carbon(self):
+        k = (1.0 + self.fuel_esc) / (1.0 + self.discount_rate)
+        return k * (1.0 - pow(k, self.lifetime)) * self.annuity_factor / (1.0 - k)
+
+    def calc_levelization_factor_carbon(self):
         """Calculate the levelizing factor for carbon."""
+
         k = (1.0 + self.carbon_esc) / (1.0 + self.discount_rate)
-        return k * (1.0 - np.power(k, self.lifetime)) * self.calc_annuity_factor() / (1.0 - k)
+        return k * (1.0 - pow(k, self.lifetime)) * self.annuity_factor / (1.0 - k)
 
     def calc_nov(self):
-        """Calculate NOV array for the target technology."""
-        term1 = self.unit_size * self.cap_fact * 8760
-        term2 = self.lmp_arr * self.calc_lf_fuel()
-        term3 = self.variable_om * self.calc_lf_vom()
-        term4 = self.heat_rate * (self.fuel_price / 1000) * self.calc_lf_fuel()
-        term5 = (self.carbon_tax * self.fuel_co2 * self.heat_rate * self.calc_lf_carbon() / 1000000) * \
-                (1 - self.carbon_capture)
+        """Calculate NOV array for all technologies."""
+
+        term1 = self.unit_size * self.capacity_factor * self.hours_per_year
+        term2 = self.lmp_arr * self.lf_fuel
+        term3 = self.variable_om * self.lf_vom
+        term4 = self.heat_rate * (self.fuel_price / 1000) * self.lf_fuel
+        term5 = (self.carbon_tax * self.fuel_co2_content * self.heat_rate * self.lf_carbon / 1000000) * (
+                    1 - self.carbon_capture_rate)
 
         return term1 * (term2 - (term3 + term4 + term5))

--- a/cerf/tests/test_nov.py
+++ b/cerf/tests/test_nov.py
@@ -9,115 +9,133 @@ License:  BSD 2-Clause, see LICENSE and DISCLAIMER files
 
 import unittest
 
+import numpy as np
+
 from cerf import NetOperationalValue
 
 
 class TestNov(unittest.TestCase):
     """Tests for the NOV calculations."""
 
-    # unit size in MW
-    UNIT_SIZE = 1350
+    # inputs as they would come from GCAM and input sources
+    DISCOUNT_RATE = 0.05  # fraction
+    LIFETIME = 60  # years
+    UNIT_SIZE = 1350  # megawatt
+    CAPACITY_FACTOR = 0.9  # fraction
+    VARIABLE_COST_ESC_RATE = -0.00104311614063357  # fraction
+    FUEL_ESC_RATE = 0.04639  # fraction
+    CARBON_ESC_RATE = 0.0  # fraction
+    VARIABLE_OM = 2.09812782440284  # $/MWh
+    HEAT_RATE = 10246.19999999998  # Btu/kWh
+    FUEL_PRICE = 0.712809999999999  # $/GJ gets converted to $/MBtu in code
+    CARBON_TAX = 0.0  # $/ton
+    CARBON_CAPTURE_RATE = 0.0  # fraction
+    FUEL_CO2_CONTENT = 0.0  # tons/MWh gets converted to tons/Btu in code
+    LMP_ARR = np.array([66.95609874])  # $/MWh
 
-    # a single LMP for simplification
-    LMP = 120.1228824
-
-    TECH_DICT = {'lifetime': 60.0,
-                    'capacity_factor': 0.9,
-                    'variable_om_esc_rate': -0.00104311614063357,
-                    'fuel_esc_rate': 0.046979999999999945,
-                    'interconnection_cost_per_km': 1104,
-                    'variable_om': 2.0819883795997414,
-                    'heat_rate': 10246.19999999998,
-                    'fuel_price': 0.7810699999999998,
-                    'carbon_capture_rate': 0.0,
-                    'fuel_co2_content': 0.0,
-                    'cf_lmp': 0.8,
-                    'discount_rate': 0.05,
-                    'carbon_esc_rate': 0.0,
-                    'carbon_tax': 0}
-
-    # expected values from calculations
+    # expected values
     EXPECTED_ANNUITY_FACTOR = 0.05282818452724236
     EXPECTED_LF_VOM = 0.9819019248539469
-    EXPECTED_LF_FUEL = 2.906727029767612
+    EXPECTED_LF_FUEL = 2.8587075325530398
     EXPECTED_LF_CARBON = 0.999999999999999
-    EXPECTED_NOV = 3446945830.7706785
+
+    # difference in expected values when evaluating under different conditions
+    EXPECTED_NOV_NOCARBON_NOLEAP = np.array([1780847345.1014912])
+    EXPECTED_NOV_NOCARBON_LEAP = np.array([1785726378.923687])
+    EXPECTED_NOV_WITHCARBON_NOLEAP = np.array([1780847344.7371392])
 
     @classmethod
-    def instantiate_nov(cls):
-        """Instantiate NOV class with test values."""
+    def instantiate_nov(cls, target_year, carbon_tax, fuel_co2_content, carbon_capture_rate):
+        """Instantiate NOV class with test values.  The additional parameters can be passed to
+        test NOV under different carbon conditions."""
 
-        return NetOperationalValue(discount_rate=cls.TECH_DICT['discount_rate'],
-                                   lifetime=cls.TECH_DICT['lifetime'],
+        return NetOperationalValue(discount_rate=cls.DISCOUNT_RATE,
+                                   lifetime=cls.LIFETIME,
                                    unit_size=cls.UNIT_SIZE,
-                                   capacity_factor=cls.TECH_DICT['capacity_factor'],
-                                   variable_om_esc_rate=cls.TECH_DICT['variable_om_esc_rate'],
-                                   fuel_esc_rate=cls.TECH_DICT['fuel_esc_rate'],
-                                   carbon_esc_rate=cls.TECH_DICT['carbon_esc_rate'],
-                                   variable_om=cls.TECH_DICT['variable_om'],
-                                   heat_rate=cls.TECH_DICT['heat_rate'],
-                                   fuel_price=cls.TECH_DICT['fuel_price'],
-                                   carbon_tax=cls.TECH_DICT['carbon_tax'],
-                                   carbon_capture_rate=cls.TECH_DICT['carbon_capture_rate'],
-                                   fuel_co2_content=cls.TECH_DICT['fuel_co2_content'],
-                                   lmp_arr=cls.LMP)
+                                   capacity_factor=cls.CAPACITY_FACTOR,
+                                   variable_cost_esc_rate=cls.VARIABLE_COST_ESC_RATE,
+                                   fuel_esc_rate=cls.FUEL_ESC_RATE,
+                                   carbon_esc_rate=cls.CARBON_ESC_RATE,
+                                   variable_om=cls.VARIABLE_OM,
+                                   heat_rate=cls.HEAT_RATE,
+                                   fuel_price=cls.FUEL_PRICE,
+                                   carbon_tax=carbon_tax,
+                                   carbon_capture_rate=carbon_capture_rate,
+                                   fuel_co2_content=fuel_co2_content,
+                                   lmp_arr=cls.LMP_ARR,
+                                   target_year=target_year)
 
-    def test_annuity_factor(self):
-        """Test the calculation of annuity factor."""
+    def test_nocarbon_noleap_nov(self):
+        """Test NOV outcome with no carbon and no leap year."""
 
-        # instantiate NOV class
-        econ = self.instantiate_nov()
+        # create a no carbon, no leap year run
+        econ = self.instantiate_nov(target_year=2010,  # four digit year
+                                    carbon_tax=0.0,  # $/ton
+                                    fuel_co2_content=0.0,  # tons/MWh gets converted to tons/Btu
+                                    carbon_capture_rate=0.0  # fraction
+                                    )
 
-        # calculate annuity factor
-        af = econ.calc_annuity_factor()
+        # test the calculation of annuity factor
+        self.assertEqual(TestNov.EXPECTED_ANNUITY_FACTOR, econ.annuity_factor)
 
-        # compare against expected
-        self.assertEqual(af, TestNov.EXPECTED_ANNUITY_FACTOR)
+        # test the calculation of the levelization factor for variable OM
+        self.assertEqual(TestNov.EXPECTED_LF_VOM, econ.lf_vom)
 
-    def test_levelization_factor_vom(self):
-        """Test the calculation of the levelization factor for variable OM."""
+        # test the calculation of the levelization factor for fuel
+        self.assertEqual(TestNov.EXPECTED_LF_FUEL, econ.lf_fuel)
 
-        # instantiate NOV class
-        econ = self.instantiate_nov()
+        # test the calculation of the levelization factor for carbon
+        self.assertEqual(TestNov.EXPECTED_LF_CARBON, econ.lf_carbon)
 
-        # calculate annuity factor
-        lf = econ.calc_lf_vom()
+        # test NOV
+        np.testing.assert_array_equal(TestNov.EXPECTED_NOV_NOCARBON_NOLEAP, econ.nov)
 
-        # compare against expected
-        self.assertEqual(lf, TestNov.EXPECTED_LF_VOM)
+    def test_nocarbon_leap_nov(self):
+        """Test NOV outcome with no carbon and on a leap year."""
 
-    def test_levelization_factor_fuel(self):
-        """Test the calculation of the levelization factor for fuel."""
+        # create a no carbon, leap year run
+        econ = self.instantiate_nov(target_year=2012,  # four digit year
+                                    carbon_tax=0.0,  # $/ton
+                                    fuel_co2_content=0.0,  # tons/MWh gets converted to tons/Btu
+                                    carbon_capture_rate=0.0  # fraction
+                                    )
 
-        # instantiate NOV class
-        econ = self.instantiate_nov()
+        # test the calculation of annuity factor
+        self.assertEqual(TestNov.EXPECTED_ANNUITY_FACTOR, econ.annuity_factor)
 
-        # calculate annuity factor
-        lf = econ.calc_lf_fuel()
+        # test the calculation of the levelization factor for variable OM
+        self.assertEqual(TestNov.EXPECTED_LF_VOM, econ.lf_vom)
 
-        # compare against expected
-        self.assertEqual(lf, TestNov.EXPECTED_LF_FUEL)
+        # test the calculation of the levelization factor for fuel
+        self.assertEqual(TestNov.EXPECTED_LF_FUEL, econ.lf_fuel)
 
-    def test_levelization_factor_carbon(self):
-        """Test the calculation of the levelization factor for carbon."""
+        # test the calculation of the levelization factor for carbon
+        self.assertEqual(TestNov.EXPECTED_LF_CARBON, econ.lf_carbon)
 
-        # instantiate NOV class
-        econ = self.instantiate_nov()
+        # test NOV
+        np.testing.assert_array_equal(TestNov.EXPECTED_NOV_NOCARBON_LEAP, econ.nov)
 
-        # calculate annuity factor
-        lf = econ.calc_lf_carbon()
+    def test_with_carbon_noleap_nov(self):
+        """Test NOV outcome with carbon and not on a leap year."""
 
-        # compare against expected
-        self.assertEqual(lf, TestNov.EXPECTED_LF_CARBON)
+        # create a no carbon, leap year run
+        econ = self.instantiate_nov(target_year=2010,  # four digit year
+                                    carbon_tax=10.0,  # $/ton
+                                    fuel_co2_content=1.2,  # tons/MWh gets converted to tons/Btu
+                                    carbon_capture_rate=0.05  # fraction
+                                    )
 
-    def test_nov(self):
-        """Test the calculation of net operational value."""
+        # test the calculation of annuity factor
+        self.assertEqual(TestNov.EXPECTED_ANNUITY_FACTOR, econ.annuity_factor)
 
-        # instantiate NOV class
-        econ = self.instantiate_nov()
+        # test the calculation of the levelization factor for variable OM
+        self.assertEqual(TestNov.EXPECTED_LF_VOM, econ.lf_vom)
 
-        # calculate annuity factor
-        nov = econ.calc_nov()
+        # test the calculation of the levelization factor for fuel
+        self.assertEqual(TestNov.EXPECTED_LF_FUEL, econ.lf_fuel)
 
-        # compare against expected
-        self.assertEqual(nov, TestNov.EXPECTED_NOV)
+        # test the calculation of the levelization factor for carbon
+        self.assertEqual(TestNov.EXPECTED_LF_CARBON, econ.lf_carbon)
+
+        # test NOV
+        np.testing.assert_array_equal(TestNov.EXPECTED_NOV_WITHCARBON_NOLEAP, econ.nov)


### PR DESCRIPTION
Created a class to calculate Net Operational Value (NOV) and the tests to check it under varying conditions.

My tests were checked against the following spreadsheet for accuracy as verified by @jenniesrice :
[cerf_nov_test_16february2021.xlsx](https://github.com/IMMM-SFA/cerf/files/6038073/cerf_nov_test_16february2021.xlsx)

Each individual part of the NOV formula can be viewed.  NOV is returned as a multi-dimensional NumPy array where the dimensions are [tech_id, x, y].

The `NetOperationalValue` class is fully documented and help can be called on it like:
```python
help(NetOperationalValue)
```
which returns,
```
Help on class NetOperationalValue in module __main__:

class NetOperationalValue(builtins.object)
 |  Calculate Net Operational Value (NOV) in ($ / yr) per grid cell for all technologies.
 |  
 |  :param discount_rate:                   The time value of money in real terms.
 |                                          Units:  fraction
 |  :type discount_rate:                    float
 |  
 |  :param lifetime:                        Years of the expected technology plant lifetime.
 |                                          Units:  years
 |  :type lifetime:                         int
 |  
 |  :param unit_size:                       The size of the expected power plant.
 |                                          Units:  megawatt
 |  :type unit_size:                        int
 |  
 |  :param capacity_factor:                 Capacity factor defined as average annual power generated divided by the
 |                                          potential output if the plant operated at its rated capacity for a year.
 |                                          Units:  fraction
 |  :type capacity_factor:                  float
 |  
 |  :param variable_cost_esc_rate:          Escalation rate of variable cost.
 |                                          Units:  fraction
 |  :type variable_cost_esc_rate:           float
 |  
 |  :param fuel_esc_rate:                   Escalation rate of fuel.
 |                                          Units:  fraction
 |  :type fuel_esc_rate:                    float
 |  
 |  :param carbon_esc_rate:                 Escalation rate of carbon.
 |                                          Units:  fraction
 |  :type carbon_esc_rate:                  float
 |  
 |  :param variable_om:                     Variable operation and maintenance costs of yearly capacity use.
 |                                          Units:  $/MWh
 |  :type variable_om:                      float
 |  
 |  :param heat_rate:                       Amount of energy used by a power plant to generate one kilowatt-hour of
 |                                          electricity.
 |                                          Units:  Btu/kWh
 |  :type heat_rate:                        float
 |  
 |  :param fuel_price:                      Cost of fuel per unit.
 |                                          Units:  from GCAM ($/GJ) gets converted to ($/MBtu)
 |  :type fuel_price:                       float
 |  
 |  :param carbon_tax:                      The fee imposed on the burning of carbon-based fuels.
 |                                          Units:  $/ton
 |  :type carbon_tax:                       float
 |  
 |  :param carbon_capture_rate:             Rate of carbon capture.
 |                                          Units:  fraction
 |  :type carbon_capture_rate:              float
 |  
 |  :param fuel_co2_content:                CO2 content of the fuel and the heat rate of the technology.
 |                                          Units:  from GCAM (tons/MWh) gets converted to (tons/Btu)
 |  :type fuel_co2_content:                 float
 |  
 |  :param lmp_arr:                         Locational Marginal Price (LMP) per grid cell for each technology in a
 |                                          multi-dimensional array where the shape is [tech_id, xcoord, ycoord].
 |                                          Units:  $/MWh
 |  :type lmp_arr:                          ndarray
 |  
 |  Methods defined here:
 |  
 |  __init__(self, discount_rate, lifetime, unit_size, capacity_factor, variable_cost_esc_rate, fuel_esc_rate, carbon_esc_rate, variable_om, heat_rate, fuel_price, carbon_tax, carbon_capture_rate, fuel_co2_content, lmp_arr, target_year)
 |      Initialize self.  See help(type(self)) for accurate signature.
 |  
 |  calc_annuity_factor(self)
 |      Calculate annuity factor.
 |  
 |  calc_levelization_factor_carbon(self)
 |      Calculate the levelizing factor for carbon.
 |  
 |  calc_levelization_factor_fuel(self)
 |      Calculate the levelizing factor for fuel.
 |  
 |  calc_levelization_factor_vom(self)
 |      Calculate the levelizing factor for variable OM.
 |  
 |  calc_nov(self)
 |      Calculate NOV array for all technologies.
 |  
 |  ----------------------------------------------------------------------
 |  Class methods defined here:
 |  
 |  assign_hours_per_year(target_year) from builtins.type
 |      Assign the hours per year based on whether or not the target year is a leap year.
 |  
 |  ----------------------------------------------------------------------
 |  Static methods defined here:
 |  
 |  convert_fuel_co2_content(fuel_co2_content)
 |      Convert fuel CO2 content from units tons/MWh to tons/Btu
 |  
 |  convert_fuel_price(fuel_price)
 |      Convert fuel price from units $/GJ to $/MBtu
 |  
 |  ----------------------------------------------------------------------
 |  Data descriptors defined here:
 |  
 |  __dict__
 |      dictionary for instance variables (if defined)
 |  
 |  __weakref__
 |      list of weak references to the object (if defined)
 |  
 |  ----------------------------------------------------------------------
 |  Data and other attributes defined here:
 |  
 |  FUEL_CO2_CONTENT_CONVERSION_FACTOR = 2.93071e-07
 |  
 |  FUEL_PRICE_CONVERSION_FACTOR = 1.055056
 |  
 |  HOURS_PER_YEAR_LEAP = 8784
 |  
 |  HOURS_PER_YEAR_NONLEAP = 8760
```

Instantiate using the following:
```python
econ =  NetOperationalValue(discount_rate=<your value>,
                           lifetime=<your value>,
                           unit_size=<your value>,
                           capacity_factor=<your value>,
                           variable_cost_esc_rate=<your value>,
                           fuel_esc_rate=<your value>,
                           carbon_esc_rate=<your value>,
                           variable_om=<your value>,
                           heat_rate=<your value>,
                           fuel_price=<your value>,
                           carbon_tax=<your value>,
                           carbon_capture_rate=<your value>,
                           fuel_co2_content=<your value>,
                           lmp_arr=<your value>,
                           target_year=<your value>)
```
NOV can then be calculated by getting the attribute from the class instantiation (e.g., the `econ` variable above):
```python 
your_nov_array = econ.nov
```
