### PR TITLE
Build parallel capability to run all states at once

### DIFF
--- a/cerf/__init__.py
+++ b/cerf/__init__.py
@@ -1,5 +1,6 @@
 from cerf.model import *
 from cerf.install_supplement import *
-from cerf.nov import NetOperationalValue
+from cerf.parallel import run_parallel
 
-__all__ = ['model', 'InstallSupplement', 'NetOperationalValue']
+
+__all__ = ['model', 'InstallSupplement', 'run_parallel']

--- a/cerf/compete.py
+++ b/cerf/compete.py
@@ -127,6 +127,7 @@ class Competition:
                         sited_list.append(target_ix)
 
                         # TODO:  make buffer inheritance to next suitability year optional
+                        # TODO:  write out exclusion data after buffer applied
                         # apply buffer
                         result = buffer_flat_array(target_index=target_ix,
                                                    arr=self.cheapest_arr_1d,

--- a/cerf/model.py
+++ b/cerf/model.py
@@ -17,6 +17,12 @@ from cerf.stage import Stage
 
 
 class Model(ReadConfig):
+    """Model wrapper for CERF.
+
+    :param config_file:                 Full path with file name and extension to the input config.yml file
+    :type config_file:                  str
+
+    """
 
     # type hints
     config_file: str

--- a/cerf/parallel.py
+++ b/cerf/parallel.py
@@ -1,0 +1,102 @@
+"""Parallelization module for CERF
+
+@author Chris R. vernon
+@email chris.vernon@pnnl.gov
+
+License:  BSD 2-Clause, see LICENSE and DISCLAIMER files
+
+"""
+
+import logging
+import os
+import time
+
+from joblib import Parallel, delayed
+import numpy as np
+
+from cerf.model import Model
+from cerf.process_state import process_state
+import cerf.utils as util
+
+
+def generate_model(config_file):
+    """Generate model instance and stage data."""
+
+    # instantiate model
+    return Model(config_file)
+
+
+def cerf_parallel(model, data, write_output=True, n_jobs=-1, method='sequential'):
+    """Run all states in parallel"""
+
+    # start time for parallel run
+    t0 = time.time()
+
+    # run all states in parallel
+    results = Parallel(n_jobs=n_jobs, backend=method)(delayed(process_state)(target_state_name=i,
+                                                                             settings_dict=model.settings_dict,
+                                                                             technology_dict=model.technology_dict,
+                                                                             technology_order=model.technology_order,
+                                                                             expansion_dict=model.expansion_dict,
+                                                                             states_dict=model.states_dict,
+                                                                             suitability_arr=data.suitability_arr,
+                                                                             nlc_arr=data.nlc_arr,
+                                                                             randomize=model.settings_dict.get('randomize', True),
+                                                                             seed_value=model.settings_dict.get('seed_value', 0),
+                                                                             verbose=model.settings_dict.get('verbose', False),
+                                                                             write_output=False) for i in model.states_dict.keys())
+
+    logging.info(f"All states processed in {round((time.time() - t0), 7)} seconds.")
+
+    # aggregate results into a single raster
+    array_shape = results[0].shape
+    n_techs = len(results)
+
+    # construct a 3D array to house outputs
+    result_arr_3d = np.zeros(shape=(n_techs, array_shape[0], array_shape[1]))
+
+    # add results to 3D array
+    for index in range(n_techs):
+        result_arr_3d[index, :, :] = results[index]
+
+    # create a 2D array that aggregates all individual state results; all NaN elements become 0.0
+    result_arr_2d = np.nansum(result_arr_3d, axis=0)
+
+    # replace 0 with NaN
+    result_arr_2d = np.where(result_arr_2d == 0, np.nan, result_arr_2d)
+
+    if write_output:
+
+        # output raster file for sited power plants
+        out_file = os.path.join(model.settings_dict.get('output_directory'), f"cerf_sited_{model.settings_dict.get('run_year')}_conus.tif")
+        logging.info(f"Aggregated outputs for all states to raster file:  {out_file}")
+
+        # write output using a template to prescribe the metadata
+        template_raster = model.technology_dict[model.technology_order[0]]['interconnection_distance_raster_file']
+        util.array_to_raster(result_arr_2d, template_raster, out_file)
+
+    return result_arr_2d
+
+
+def run_parallel(config_file):
+
+    model = generate_model(config_file)
+
+    data = model.stage()
+
+    res = cerf_parallel(model, data)
+
+    logging.info(f"CERF model run completed in {round(time.time() - model.start_time, 7)}")
+
+    model.close_logger()
+
+    return res
+
+
+if __name__ == '__main__':
+
+    import pkg_resources
+
+    c = pkg_resources.resource_filename('cerf', 'tests/data/config.yml')
+
+    opt = run_parallel(c)

--- a/cerf/process_state.py
+++ b/cerf/process_state.py
@@ -151,9 +151,10 @@ class ProcessState:
     def competition(self):
         """Compete technologies."""
 
-        comp = Competition(technology_dict=self.technology_dict,
+        comp = Competition(target_state_name=self.target_state_name,
+                           technology_dict=self.technology_dict,
                            technology_order=self.technology_order,
-                           expansion_dict=self.expansion_dict,
+                           expansion_dict=self.expansion_dict[self.target_state_name],
                            nlc_mask=self.suitable_nlc_state,
                            randomize=self.randomize,
                            seed_value=self.seed_value,
@@ -237,23 +238,33 @@ def process_state(target_state_name, settings_dict, technology_dict, technology_
 
     logging.info(f'Processing state:  {target_state_name}')
 
-    # initial time for processing state
-    state_t0 = time.time()
+    # check to see if state has any sites in the expansion
+    n_sites = sum([expansion_dict[target_state_name][k]['n_sites'] for k in expansion_dict[target_state_name].keys()])
 
-    # process expansion plan and competition for a single state for the target year
-    process = ProcessState(settings_dict=settings_dict,
-                           technology_dict=technology_dict,
-                           technology_order=technology_order,
-                           expansion_dict=expansion_dict,
-                           states_dict=states_dict,
-                           suitability_arr=suitability_arr,
-                           nlc_arr=nlc_arr,
-                           target_state_name=target_state_name,
-                           randomize=randomize,
-                           seed_value=seed_value,
-                           verbose=verbose,
-                           write_output=write_output)
+    # if there are no sites in the expansion, return an all NaN 2D array
+    if n_sites <= 0:
+        logging.warning(f"There were no sites expected for any technology in `{target_state_name}`")
+        return nlc_arr[0, :, :] * np.nan
 
-    logging.info(f'Processed `{target_state_name}` in {round(time.time() - state_t0, 7)} seconds')
+    else:
 
-    return process.sited_arr
+        # initial time for processing state
+        state_t0 = time.time()
+
+        # process expansion plan and competition for a single state for the target year
+        process = ProcessState(settings_dict=settings_dict,
+                               technology_dict=technology_dict,
+                               technology_order=technology_order,
+                               expansion_dict=expansion_dict,
+                               states_dict=states_dict,
+                               suitability_arr=suitability_arr,
+                               nlc_arr=nlc_arr,
+                               target_state_name=target_state_name,
+                               randomize=randomize,
+                               seed_value=seed_value,
+                               verbose=verbose,
+                               write_output=write_output)
+
+        logging.info(f'Processed `{target_state_name}` in {round(time.time() - state_t0, 7)} seconds')
+
+        return process.sited_arr

--- a/cerf/read_config.py
+++ b/cerf/read_config.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import pkg_resources
 
 import yaml
 
@@ -41,6 +42,16 @@ class ReadConfig(Logger):
         # get the utility zone data
         self.utility_dict = self.config.get('utility_zones')
 
+        # get the states dictionary
+        self.states_dict = self.get_states_dict()
+
+    @staticmethod
+    def read_yaml(yaml_file):
+        """Read a YAML file."""
+
+        with open(yaml_file, 'r') as yml:
+            return yaml.load(yml, Loader=yaml.FullLoader)
+
     def get_yaml(self):
         """Read the YAML config file.
 
@@ -57,10 +68,17 @@ class ReadConfig(Logger):
         # check for path exists
         if os.path.isfile(self.config_file):
 
-            with open(self.config_file, 'r') as yml:
-                return yaml.load(yml, Loader=yaml.FullLoader)
+            return self.read_yaml(self.config_file)
 
         else:
             msg = f"Config file not found for path:  {self.config_file}"
             logging.info(msg)
             raise FileNotFoundError(msg)
+
+    def get_states_dict(self):
+        """Get a dictionary of state name to state ID from the YAML file in package data."""
+
+        # in package data {state_name: state_id}
+        states_lookup_file = pkg_resources.resource_filename('cerf', 'data/state-name_to_state-id.yml')
+
+        return self.read_yaml(states_lookup_file)

--- a/cerf/tests/data/config.yml
+++ b/cerf/tests/data/config.yml
@@ -1,5 +1,5 @@
 # project settings
-#TODO:  Select which outputs to write    
+#TODO:  Select which outputs to write
 settings:
 
     # target year to run
@@ -533,6 +533,15 @@ utility_zones:
 
         51:
             zone_name: zone_51
+            lmp: 79.20000000000061
+            lmp_by_capacity_factor:
+                0.8: 81.70000000000061
+                0.5: 89.70000000000061
+                0.3: 99.70000000000061
+                0.1: 158.40000000000123
+
+        52:
+            zone_name: zone_52
             lmp: 79.20000000000061
             lmp_by_capacity_factor:
                 0.8: 81.70000000000061

--- a/cerf/tests/data/config.yml
+++ b/cerf/tests/data/config.yml
@@ -66,8 +66,447 @@ technology:
 # expansion plan from GCAM
 expansion_plan:
 
-    9: 20
-    11: 25
+    alabama:
+        9:
+            tech_name: biomass_conv
+            n_sites: 0
+
+        11:
+            tech_name: nuclear
+            n_sites: 4
+
+    arizona:
+        9:
+            tech_name: biomass_conv
+            n_sites: 5
+
+        11:
+            tech_name: nuclear
+            n_sites: 0
+
+    arkansas:
+        9:
+            tech_name: biomass_conv
+            n_sites: 10
+
+        11:
+            tech_name: nuclear
+            n_sites: 3
+
+    california:
+        9:
+            tech_name: biomass_conv
+            n_sites: 1
+
+        11:
+            tech_name: nuclear
+            n_sites: 2
+
+    colorado:
+        9:
+            tech_name: biomass_conv
+            n_sites: 9
+
+        11:
+            tech_name: nuclear
+            n_sites: 1
+
+    connecticut:
+        9:
+            tech_name: biomass_conv
+            n_sites: 2
+
+        11:
+            tech_name: nuclear
+            n_sites: 9
+
+    delaware:
+        9:
+            tech_name: biomass_conv
+            n_sites: 4
+
+        11:
+            tech_name: nuclear
+            n_sites: 9
+
+    district_of_columbia:
+        9:
+            tech_name: biomass_conv
+            n_sites: 9
+
+        11:
+            tech_name: nuclear
+            n_sites: 4
+
+    florida:
+        9:
+            tech_name: biomass_conv
+            n_sites: 8
+
+        11:
+            tech_name: nuclear
+            n_sites: 4
+
+    georgia:
+        9:
+            tech_name: biomass_conv
+            n_sites: 6
+
+        11:
+            tech_name: nuclear
+            n_sites: 3
+
+    idaho:
+        9:
+            tech_name: biomass_conv
+            n_sites: 10
+
+        11:
+            tech_name: nuclear
+            n_sites: 9
+
+    illinois:
+        9:
+            tech_name: biomass_conv
+            n_sites: 1
+
+        11:
+            tech_name: nuclear
+            n_sites: 8
+
+    indiana:
+        9:
+            tech_name: biomass_conv
+            n_sites: 4
+
+        11:
+            tech_name: nuclear
+            n_sites: 6
+
+    iowa:
+        9:
+            tech_name: biomass_conv
+            n_sites: 4
+
+        11:
+            tech_name: nuclear
+            n_sites: 4
+
+    kansas:
+        9:
+            tech_name: biomass_conv
+            n_sites: 5
+
+        11:
+            tech_name: nuclear
+            n_sites: 7
+
+    kentucky:
+        9:
+            tech_name: biomass_conv
+            n_sites: 7
+
+        11:
+            tech_name: nuclear
+            n_sites: 1
+
+    louisiana:
+        9:
+            tech_name: biomass_conv
+            n_sites: 4
+
+        11:
+            tech_name: nuclear
+            n_sites: 4
+
+    maine:
+        9:
+            tech_name: biomass_conv
+            n_sites: 3
+
+        11:
+            tech_name: nuclear
+            n_sites: 4
+
+    maryland:
+        9:
+            tech_name: biomass_conv
+            n_sites: 3
+
+        11:
+            tech_name: nuclear
+            n_sites: 7
+
+    massachusetts:
+        9:
+            tech_name: biomass_conv
+            n_sites: 5
+
+        11:
+            tech_name: nuclear
+            n_sites: 10
+
+    michigan:
+        9:
+            tech_name: biomass_conv
+            n_sites: 1
+
+        11:
+            tech_name: nuclear
+            n_sites: 10
+
+    minnesota:
+        9:
+            tech_name: biomass_conv
+            n_sites: 0
+
+        11:
+            tech_name: nuclear
+            n_sites: 9
+
+    mississippi:
+        9:
+            tech_name: biomass_conv
+            n_sites: 5
+
+        11:
+            tech_name: nuclear
+            n_sites: 2
+
+    missouri:
+        9:
+            tech_name: biomass_conv
+            n_sites: 0
+
+        11:
+            tech_name: nuclear
+            n_sites: 0
+
+    montana:
+        9:
+            tech_name: biomass_conv
+            n_sites: 9
+
+        11:
+            tech_name: nuclear
+            n_sites: 1
+
+    nebraska:
+        9:
+            tech_name: biomass_conv
+            n_sites: 1
+
+        11:
+            tech_name: nuclear
+            n_sites: 9
+
+    nevada:
+        9:
+            tech_name: biomass_conv
+            n_sites: 4
+
+        11:
+            tech_name: nuclear
+            n_sites: 8
+
+    new_hampshire:
+        9:
+            tech_name: biomass_conv
+            n_sites: 3
+
+        11:
+            tech_name: nuclear
+            n_sites: 6
+
+    new_jersey:
+        9:
+            tech_name: biomass_conv
+            n_sites: 4
+
+        11:
+            tech_name: nuclear
+            n_sites: 1
+
+    new_mexico:
+        9:
+            tech_name: biomass_conv
+            n_sites: 0
+
+        11:
+            tech_name: nuclear
+            n_sites: 8
+
+    new_york:
+        9:
+            tech_name: biomass_conv
+            n_sites: 8
+
+        11:
+            tech_name: nuclear
+            n_sites: 6
+
+    north_carolina:
+        9:
+            tech_name: biomass_conv
+            n_sites: 6
+
+        11:
+            tech_name: nuclear
+            n_sites: 9
+
+    north_dakota:
+        9:
+            tech_name: biomass_conv
+            n_sites: 9
+
+        11:
+            tech_name: nuclear
+            n_sites: 10
+
+    ohio:
+        9:
+            tech_name: biomass_conv
+            n_sites: 6
+
+        11:
+            tech_name: nuclear
+            n_sites: 7
+
+    oklahoma:
+        9:
+            tech_name: biomass_conv
+            n_sites: 10
+
+        11:
+            tech_name: nuclear
+            n_sites: 1
+
+    oregon:
+        9:
+            tech_name: biomass_conv
+            n_sites: 1
+
+        11:
+            tech_name: nuclear
+            n_sites: 7
+
+    pennsylvania:
+        9:
+            tech_name: biomass_conv
+            n_sites: 10
+
+        11:
+            tech_name: nuclear
+            n_sites: 4
+
+    rhode_island:
+        9:
+            tech_name: biomass_conv
+            n_sites: 10
+
+        11:
+            tech_name: nuclear
+            n_sites: 7
+
+    south_carolina:
+        9:
+            tech_name: biomass_conv
+            n_sites: 3
+
+        11:
+            tech_name: nuclear
+            n_sites: 5
+
+    south_dakota:
+        9:
+            tech_name: biomass_conv
+            n_sites: 5
+
+        11:
+            tech_name: nuclear
+            n_sites: 8
+
+    tennessee:
+        9:
+            tech_name: biomass_conv
+            n_sites: 1
+
+        11:
+            tech_name: nuclear
+            n_sites: 6
+
+    texas:
+        9:
+            tech_name: biomass_conv
+            n_sites: 1
+
+        11:
+            tech_name: nuclear
+            n_sites: 10
+
+    utah:
+        9:
+            tech_name: biomass_conv
+            n_sites: 3
+
+        11:
+            tech_name: nuclear
+            n_sites: 9
+
+    vermont:
+        9:
+            tech_name: biomass_conv
+            n_sites: 5
+
+        11:
+            tech_name: nuclear
+            n_sites: 2
+
+    virginia:
+        9:
+            tech_name: biomass_conv
+            n_sites: 2
+
+        11:
+            tech_name: nuclear
+            n_sites: 8
+
+    washington:
+        9:
+            tech_name: biomass_conv
+            n_sites: 6
+
+        11:
+            tech_name: nuclear
+            n_sites: 7
+
+    west_virginia:
+        9:
+            tech_name: biomass_conv
+            n_sites: 7
+
+        11:
+            tech_name: nuclear
+            n_sites: 4
+
+    wisconsin:
+        9:
+            tech_name: biomass_conv
+            n_sites: 1
+
+        11:
+            tech_name: nuclear
+            n_sites: 9
+
+    wyoming:
+        9:
+            tech_name: biomass_conv
+            n_sites: 6
+
+        11:
+            tech_name: nuclear
+            n_sites: 2
+
 
 # utility zone specific data
 # TODO:  may not need preset bins
@@ -542,6 +981,54 @@ utility_zones:
 
         52:
             zone_name: zone_52
+            lmp: 79.20000000000061
+            lmp_by_capacity_factor:
+                0.8: 81.70000000000061
+                0.5: 89.70000000000061
+                0.3: 99.70000000000061
+                0.1: 158.40000000000123
+
+        53:
+            zone_name: zone_53
+            lmp: 79.20000000000061
+            lmp_by_capacity_factor:
+                0.8: 81.70000000000061
+                0.5: 89.70000000000061
+                0.3: 99.70000000000061
+                0.1: 158.40000000000123
+
+
+        54:
+            zone_name: zone_54
+            lmp: 79.20000000000061
+            lmp_by_capacity_factor:
+                0.8: 81.70000000000061
+                0.5: 89.70000000000061
+                0.3: 99.70000000000061
+                0.1: 158.40000000000123
+
+
+        55:
+            zone_name: zone_55
+            lmp: 79.20000000000061
+            lmp_by_capacity_factor:
+                0.8: 81.70000000000061
+                0.5: 89.70000000000061
+                0.3: 99.70000000000061
+                0.1: 158.40000000000123
+
+
+        56:
+            zone_name: zone_56
+            lmp: 79.20000000000061
+            lmp_by_capacity_factor:
+                0.8: 81.70000000000061
+                0.5: 89.70000000000061
+                0.3: 99.70000000000061
+                0.1: 158.40000000000123
+
+        57:
+            zone_name: zone_57
             lmp: 79.20000000000061
             lmp_by_capacity_factor:
                 0.8: 81.70000000000061

--- a/cerf/tests/test_compete.py
+++ b/cerf/tests/test_compete.py
@@ -7,7 +7,9 @@ from cerf.compete import Competition
 
 class TestCompete(unittest.TestCase):
 
-    EXPANSION_PLAN = {1: 1, 2: 1, 3: 1}  # n sites per tech
+    EXPANSION_PLAN = {1: {'n_sites': 1, 'tech_name': 'test1'},
+                      2: {'n_sites': 1, 'tech_name': 'test2'},
+                      3: {'n_sites': 1, 'tech_name': 'test3'}}  # n sites per tech
     TECH_DICT = {1: {'buffer_in_km': 1}, 2: {'buffer_in_km': 1}, 3: {'buffer_in_km': 1}}  # buffer per tech
     TECH_ORDER = [1, 2, 3]
 
@@ -36,7 +38,9 @@ class TestCompete(unittest.TestCase):
                            [0, 1, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0]])
 
-    COMP_EXP_PLAN = {1: 0, 2: 0, 3: 0}
+    COMP_EXP_PLAN = {1: {'n_sites': 0, 'tech_name': 'test1'},
+                     2: {'n_sites': 0, 'tech_name': 'test2'},
+                     3: {'n_sites': 0, 'tech_name': 'test3'}}
 
     @classmethod
     def create_masked_nlc_array(cls):
@@ -57,7 +61,8 @@ class TestCompete(unittest.TestCase):
         # create a fake NLC masked array to use for testing
         nlc_arr = self.create_masked_nlc_array()
 
-        comp = Competition(technology_dict=TestCompete.TECH_DICT,
+        comp = Competition(target_state_name='test',
+                           technology_dict=TestCompete.TECH_DICT,
                            technology_order=TestCompete.TECH_ORDER,
                            expansion_dict=TestCompete.EXPANSION_PLAN,
                            nlc_mask=nlc_arr,

--- a/cerf/tests/test_nov.py
+++ b/cerf/tests/test_nov.py
@@ -11,7 +11,7 @@ import unittest
 
 import numpy as np
 
-from cerf import NetOperationalValue
+from cerf.nov import NetOperationalValue
 
 
 class TestNov(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ seaborn>=0.8.1
 PyYAML>=5.3.1
 requests>=2.24.0
 rasterio>=1.1.3
+joblib>=1.0.1


### PR DESCRIPTION
Run all states at once for a target year with this parallel capability.  This will be accessible to the user like:

```python
import cerf

# my config file
config_file = "<path to my config yaml file>"

# run all states in parallel
result = cerf.run_parallel(config_file)
```
Instantiating the model and staging the data takes place first so that the state level expansions can use the common pool of data.  These have to be wrapped as functions outside the scope of their classes so that Python may correctly allocate them.

The result is a 2D array where each tech_id is sited on it's grid cell.  Cells that do not have a sited value are given NaN.  