### PR TITLE
Create CSV output option

### DIFF
--- a/cerf/compete.py
+++ b/cerf/compete.py
@@ -51,6 +51,8 @@ class Competition:
                  technology_order,
                  expansion_dict,
                  nlc_mask,
+                 xcoords,
+                 ycoords,
                  randomize=True,
                  seed_value=0,
                  verbose=False):
@@ -78,6 +80,16 @@ class Competition:
         # number of technologies
         self.n_techs = len(self.technology_order)
 
+        # dictionary to hold sited information
+        self.sited_dict = {'index': [],
+                           'xcoord': [],
+                           'ycoord': [],
+                           'nlc': []}
+
+        # coordinates for each index
+        self.xcoords = xcoords
+        self.ycoords = ycoords
+
         # show cheapest option, add 1 to the index to represent the technology number
         self.cheapest_arr = np.argmin(self.nlc_mask, axis=0)
 
@@ -94,7 +106,7 @@ class Competition:
         self.nlc_flat_dict = {i: self.nlc_mask[ix, :, :].flatten() for ix, i in enumerate(self.technology_order)}
 
         # run competition and site
-        self.sited_array, self.expansion_dict = self.compete()
+        self.sited_array = self.compete()
 
         # evaluate sites to see if expansion plan was met
         self.log_outcome()
@@ -111,9 +123,6 @@ class Competition:
                 logging.warning(f"Unable to achieve full siting for `{tech_name}` in `{self.target_state_name}`:  {remaining_sites} unsited.")
 
     def compete(self):
-
-        # dictionary of iterations per technology
-        iter_dict = {}
 
         # initialize keep sighting designation; False if no more sites or area to site
         keep_siting = True
@@ -149,6 +158,17 @@ class Competition:
 
                         # select a random index that has a winning cell for the check where multiple low NLC may exists
                         target_ix = np.random.choice(tech_nlc_cheap)
+
+                        try:
+                            # add selected index to sited dictionary
+                            self.sited_dict['index'].append(target_ix)
+                            self.sited_dict['xcoord'].append(self.xcoords[target_ix])
+                            self.sited_dict['ycoord'].append(self.ycoords[target_ix])
+                            self.sited_dict['nlc'].append(self.nlc_flat_dict[tech_id][target_ix])
+                        except IndexError:
+                            print(target_ix)
+                            print(self.xcoords.shape)
+                            raise
 
                         # add selected index to list
                         sited_list.append(target_ix)
@@ -238,4 +258,4 @@ class Competition:
                     keep_siting = False
 
         # reshape output array to 2D
-        return self.sited_arr_1d.reshape(self.cheapest_arr.shape), self.expansion_dict
+        return self.sited_arr_1d.reshape(self.cheapest_arr.shape)

--- a/cerf/compete.py
+++ b/cerf/compete.py
@@ -1,6 +1,7 @@
 import logging
 
 import numpy as np
+import pandas as pd
 
 from cerf.utils import buffer_flat_array
 
@@ -130,7 +131,7 @@ class Competition:
         self.nlc_flat_dict = {i: self.nlc_mask[ix+1, :, :].flatten() for ix, i in enumerate(self.technology_order)}
 
         # run competition and site
-        self.sited_array = self.compete()
+        self.sited_array, self.sited_df = self.compete()
 
         # evaluate sites to see if expansion plan was met
         self.log_outcome()
@@ -282,4 +283,4 @@ class Competition:
                     keep_siting = False
 
         # reshape output array to 2D
-        return self.sited_arr_1d.reshape(self.cheapest_arr.shape)
+        return self.sited_arr_1d.reshape(self.cheapest_arr.shape), pd.DataFrame(self.sited_dict)

--- a/cerf/lmp.py
+++ b/cerf/lmp.py
@@ -1,5 +1,4 @@
 import numpy as np
-import rasterio
 
 
 class LocationalMarginalPricing:
@@ -24,12 +23,7 @@ class LocationalMarginalPricing:
 
     """
 
-    # type hints
-    utility_dict: dict
-    technology_dict: dict
-    technology_order: list
-
-    def __init__(self, utility_dict, technology_dict, technology_order):
+    def __init__(self, utility_dict, technology_dict, technology_order, zones_arr):
 
         # dictionary containing utility zone information
         self.utility_dict = utility_dict
@@ -40,12 +34,8 @@ class LocationalMarginalPricing:
         # order of technologies to process
         self.technology_order = technology_order
 
-        # raster file containing the utility zone per grid cell
-        zones_raster_file = self.utility_dict.get('utility_zone_raster_file')
-
-        # read in utility zones raster as a 2D numpy array
-        with rasterio.open(zones_raster_file) as src:
-            self.zones_arr = src.read(1)
+        # array containing the utility zone per grid cell
+        self.zones_arr = zones_arr
 
     @staticmethod
     def bin_cf(capacity_factor):

--- a/cerf/model.py
+++ b/cerf/model.py
@@ -62,14 +62,18 @@ class Model(ReadConfig):
         # prepare all data for state level run
         data = self.stage()
 
-        sited_arr = process_state(target_state_name=target_state_name,
+        process = process_state(target_state_name=target_state_name,
                                   settings_dict=self.settings_dict,
                                   technology_dict=self.technology_dict,
                                   technology_order=self.technology_order,
                                   expansion_dict=self.expansion_dict,
                                   states_dict=self.states_dict,
                                   suitability_arr=data.suitability_arr,
+                                  lmp_arr=data.lmp_arr,
+                                  nov_arr=data.nov_arr,
+                                  ic_arr=data.ic_arr,
                                   nlc_arr=data.nlc_arr,
+                                  zones_arr=data.zones_arr,
                                   xcoords=data.xcoords,
                                   ycoords=data.ycoords,
                                   randomize=self.settings_dict.get('randomize', True),
@@ -81,7 +85,7 @@ class Model(ReadConfig):
 
         self.close_logger()
 
-        return sited_arr
+        return process
 
 
 if __name__ == '__main__':
@@ -89,4 +93,4 @@ if __name__ == '__main__':
     import pkg_resources
 
     c = pkg_resources.resource_filename('cerf', 'tests/data/config.yml')
-    m = Model(c).run_single_state(target_state_name='virginia')
+    process = Model(c).run_single_state(target_state_name='virginia')

--- a/cerf/model.py
+++ b/cerf/model.py
@@ -70,6 +70,8 @@ class Model(ReadConfig):
                                   states_dict=self.states_dict,
                                   suitability_arr=data.suitability_arr,
                                   nlc_arr=data.nlc_arr,
+                                  xcoords=data.xcoords,
+                                  ycoords=data.ycoords,
                                   randomize=self.settings_dict.get('randomize', True),
                                   seed_value=self.settings_dict.get('seed_value', 0),
                                   verbose=self.settings_dict.get('verbose', False),
@@ -87,4 +89,4 @@ if __name__ == '__main__':
     import pkg_resources
 
     c = pkg_resources.resource_filename('cerf', 'tests/data/config.yml')
-    m = Model(c).run_single_state(target_state_name='missouri')
+    m = Model(c).run_single_state(target_state_name='virginia')

--- a/cerf/parallel.py
+++ b/cerf/parallel.py
@@ -101,7 +101,7 @@ def cerf_parallel(model, data, write_output=True, n_jobs=-1, method='sequential'
 
         # ensure some sites were able to be sited for the target state
         if i is not None:
-            df = pd.concat([df, i.sited_df])
+            df = pd.concat([df, i.run_data.sited_df])
 
     if write_output:
 

--- a/cerf/parallel.py
+++ b/cerf/parallel.py
@@ -13,6 +13,7 @@ import time
 
 from joblib import Parallel, delayed
 import numpy as np
+import pandas as pd
 
 from cerf.model import Model
 from cerf.process_state import process_state

--- a/cerf/process_state.py
+++ b/cerf/process_state.py
@@ -29,10 +29,14 @@ class ProcessState:
                  expansion_dict,
                  states_dict,
                  suitability_arr,
+                 lmp_arr,
+                 nov_arr,
+                 ic_arr,
                  nlc_arr,
+                 zones_arr,
                  xcoords,
                  ycoords,
-                 target_state_name='virginia',
+                 target_state_name,
                  randomize=True,
                  seed_value=0,
                  verbose=False,
@@ -62,8 +66,20 @@ class ProcessState:
         # suitability data for the CONUS
         self.suitability_arr = suitability_arr
 
+        # LMP array for the CONUS
+        self.lmp_arr = lmp_arr
+
+        # NOV array for the CONUS
+        self.nov_arr = nov_arr
+
+        # IC array for the CONUS
+        self.ic_arr = ic_arr
+
         # NLC data for the CONUS
         self.nlc_arr = nlc_arr
+
+        # utility zones for the CONUS
+        self.zones_arr = zones_arr
 
         # coordinates for each index
         self.xcoords = xcoords
@@ -87,8 +103,15 @@ class ProcessState:
         logging.info(f"Creating a NLC state level array for {self.target_state_name}")
         self.suitable_nlc_state = self.mask_nlc()
 
+        logging.info(f"Get grid coordinates for {self.target_state_name}")
+        self.xcoords_state, self.ycoords_state = self.get_grid_coordinates()
+
+        logging.info(f"Extracting additional metrics for {self.target_state_name}")
+        self.lmp_flat_dict, self.nov_flat_dict, self.ic_flat_dict = self.extract_state_metrics()
+        self.zones_flat_arr = self.extract_utility_zones()
+
         logging.info(f"Competing technologies to site expansion for {self.target_state_name}")
-        self.sited_arr = self.competition()
+        self.sited_arr, self.sited_df = self.competition()
 
     def get_state_id(self):
         """Load state name to state id YAML file to a dictionary.
@@ -155,6 +178,37 @@ class ProcessState:
         # apply the mask to NLC data
         return np.ma.masked_array(nlc_arr_state, mask=self.suitability_array_state)
 
+    def get_grid_coordinates(self):
+        """Generate 1D arrays of grid coordinates (X, Y) to use for siting based on the bounds of the target state."""
+
+        xcoord_2d_state = self.xcoords[self.ymin:self.ymax, self.xmin:self.xmax].flatten()
+        ycoord_2d_state = self.ycoords[self.ymin:self.ymax, self.xmin:self.xmax].flatten()
+
+        return xcoord_2d_state, ycoord_2d_state
+
+    def extract_state_metrics(self):
+        """Extract the LMP, NOV, and IC arrays for the target state and return them as dictionaries where
+        {tech_id: flat_array, ...}.
+
+        """
+
+        # extract the target state
+        lmp_arr_state = self.lmp_arr[:, self.ymin:self.ymax, self.xmin:self.xmax]
+        nov_arr_state = self.nov_arr[:, self.ymin:self.ymax, self.xmin:self.xmax]
+        ic_arr_state = self.ic_arr[:, self.ymin:self.ymax, self.xmin:self.xmax]
+
+        # create a reference dictionary where {tech_id: flat_state_array, ...}
+        lmp_flat_dict = {i: lmp_arr_state[ix, :, :].flatten() for ix, i in enumerate(self.technology_order)}
+        nov_flat_dict = {i: nov_arr_state[ix, :, :].flatten() for ix, i in enumerate(self.technology_order)}
+        ic_flat_dict = {i: ic_arr_state[ix, :, :].flatten() for ix, i in enumerate(self.technology_order)}
+
+        return lmp_flat_dict, nov_flat_dict, ic_flat_dict
+
+    def extract_utility_zones(self):
+        """Extract the utility zones elements for the target state and return as a flat array."""
+
+        return self.zones_arr[self.ymin:self.ymax, self.xmin:self.xmax].flatten()
+
     def competition(self):
         """Compete technologies."""
 
@@ -162,9 +216,13 @@ class ProcessState:
                            technology_dict=self.technology_dict,
                            technology_order=self.technology_order,
                            expansion_dict=self.expansion_dict[self.target_state_name],
+                           lmp_dict=self.lmp_flat_dict,
+                           nov_dict=self.nov_flat_dict,
+                           ic_dict=self.ic_flat_dict,
                            nlc_mask=self.suitable_nlc_state,
-                           xcoords=self.xcoords,
-                           ycoords=self.ycoords,
+                           zones_arr=self.zones_flat_arr,
+                           xcoords=self.xcoords_state,
+                           ycoords=self.ycoords_state,
                            randomize=self.randomize,
                            seed_value=self.seed_value,
                            verbose=self.verbose)
@@ -175,6 +233,9 @@ class ProcessState:
         # place final array back in grid space for all regions
         sited_arr = np.zeros_like(self.suitability_arr[0, :, :]) * np.nan
         sited_arr[self.ymin:self.ymax, self.xmin:self.xmax] = final_array
+
+        # create data frame of sited data
+        df = pd.DataFrame(comp.sited_dict)
 
         # write outputs if so desired
         if self.write_outputs:
@@ -190,14 +251,15 @@ class ProcessState:
             # create output CSV file of coordinate data
             csv_file_name = f"cerf_sited_{self.settings_dict['run_year']}_{self.target_state_name}.csv"
             csv_out_file = os.path.join(self.settings_dict.get('output_directory'), csv_file_name)
-            df = pd.DataFrame(comp.sited_dict).to_csv(csv_out_file, index=False)
 
-        return sited_arr
+            df.to_csv(csv_out_file, index=False)
+
+        return sited_arr, df
 
 
 def process_state(target_state_name, settings_dict, technology_dict, technology_order, expansion_dict, states_dict,
-                  suitability_arr, nlc_arr, xcoords, ycoords,randomize=True, seed_value=0, verbose=False,
-                  write_output=True):
+                  suitability_arr, lmp_arr, nov_arr, ic_arr, nlc_arr, zones_arr, xcoords, ycoords,randomize=True,
+                  seed_value=0, verbose=False, write_output=True):
     """Convenience wrapper to log time and site an expansion plan for a target state for the target year.
 
     :param target_state_name:                   Name of the target state as it is represented in the state raster.
@@ -257,7 +319,7 @@ def process_state(target_state_name, settings_dict, technology_dict, technology_
     # if there are no sites in the expansion, return an all NaN 2D array
     if n_sites <= 0:
         logging.warning(f"There were no sites expected for any technology in `{target_state_name}`")
-        return nlc_arr[0, :, :] * np.nan
+        return None
 
     else:
 
@@ -271,7 +333,11 @@ def process_state(target_state_name, settings_dict, technology_dict, technology_
                                expansion_dict=expansion_dict,
                                states_dict=states_dict,
                                suitability_arr=suitability_arr,
+                               lmp_arr=lmp_arr,
+                               nov_arr=nov_arr,
+                               ic_arr=ic_arr,
                                nlc_arr=nlc_arr,
+                               zones_arr=zones_arr,
                                xcoords=xcoords,
                                ycoords=ycoords,
                                target_state_name=target_state_name,
@@ -282,4 +348,4 @@ def process_state(target_state_name, settings_dict, technology_dict, technology_
 
         logging.info(f'Processed `{target_state_name}` in {round(time.time() - state_t0, 7)} seconds')
 
-        return process.sited_arr
+        return process

--- a/cerf/stage.py
+++ b/cerf/stage.py
@@ -13,6 +13,7 @@ import pkg_resources
 import rasterio
 import numpy as np
 
+import cerf.utils as util
 from cerf.lmp import LocationalMarginalPricing
 from cerf.nov import NetOperationalValue
 
@@ -40,8 +41,8 @@ class Stage:
         self.technology_order = technology_order
 
         # load coordinate data
-        self.xcoords = np.load(pkg_resources.resource_filename('cerf', 'data/conus_xcoords_albers_2d.npy'))
-        self.ycoords = np.load(pkg_resources.resource_filename('cerf', 'data/conus_ycoords_albers_2d.npy'))
+        self.cerf_stateid_raster_file = pkg_resources.resource_filename('cerf', 'data/cerf_conus_states_albers_1km.tif')
+        self.xcoords, self.ycoords = util.raster_to_coord_arrays(self.cerf_stateid_raster_file)
 
         # raster file containing the utility zone per grid cell
         self.zones_arr = self.load_utility_raster()

--- a/cerf/stage.py
+++ b/cerf/stage.py
@@ -8,6 +8,7 @@ License:  BSD 2-Clause, see LICENSE and DISCLAIMER files
 """
 
 import logging
+import pkg_resources
 
 import rasterio
 import numpy as np
@@ -37,6 +38,10 @@ class Stage:
 
         # order of technologies to process
         self.technology_order = technology_order
+
+        # load coordinate data
+        self.xcoords = np.load(pkg_resources.resource_filename('cerf', 'data/conus_xcoords_albers_1d.npy'))
+        self.ycoords = np.load(pkg_resources.resource_filename('cerf', 'data/conus_ycoords_albers_1d.npy'))
 
         # get LMP array per tech [tech_order, x, y]
         logging.info('Processing locational marginal pricing (LMP)')

--- a/cerf/tests/test_compete.py
+++ b/cerf/tests/test_compete.py
@@ -34,13 +34,23 @@ class TestCompete(unittest.TestCase):
 
     # expected outcome
     COMP_SITED = np.array([[0, 2, 0, 0, 0, 0, 0],
-                           [0, 0, 0, 0, 0, 3, 0],
-                           [0, 1, 0, 0, 0, 0, 0],
+                           [0, 0, 0, 0, 0, 0, 0],
+                           [0, 1, 0, 3, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0]])
 
     COMP_EXP_PLAN = {1: {'n_sites': 0, 'tech_name': 'test1'},
                      2: {'n_sites': 0, 'tech_name': 'test2'},
                      3: {'n_sites': 0, 'tech_name': 'test3'}}
+
+    COMP_SITED_DICT = {'state_name': ['test', 'test', 'test'],
+                       'tech_id': [1, 2, 3],
+                       'xcoord': [2.4, 3.2, 3.2],
+                       'ycoord': [2.4, 3.2, 3.2],
+                       'utility_zone': [2, 3, 3],
+                       'locational_marginal_pricing': [2.4, 1.0, 3.2],
+                       'net_operational_value': [2.4, 1.0, 3.2],
+                       'interconnection_cost': [2.4, 1.0, 3.2],
+                       'net_locational_cost': [2.4, 1.0, 3.2]}
 
     @classmethod
     def create_masked_nlc_array(cls):
@@ -55,17 +65,38 @@ class TestCompete(unittest.TestCase):
         # apply exclusion
         return np.ma.masked_array(arr, exc)
 
+    @classmethod
+    def create_proxy_arrays(cls):
+        """Create fake arrays to feed into the class."""
+
+        # fake dictionary
+        fake_dict = {i + 1: cls.NLC_ARR[i, :, :].flatten() for i in range(cls.NLC_ARR.shape[0])}
+
+        # fake flat array
+        fake_flat_arr = fake_dict[1].flatten()
+
+        return fake_dict, fake_flat_arr
+
     def test_competition(self):
         """Ensure that the competition algorithm performs as expected."""
 
         # create a fake NLC masked array to use for testing
         nlc_arr = self.create_masked_nlc_array()
 
+        # proxy dictionary and arrays
+        fake_dict, fake_flat_array = self.create_proxy_arrays()
+
         comp = Competition(target_state_name='test',
                            technology_dict=TestCompete.TECH_DICT,
                            technology_order=TestCompete.TECH_ORDER,
                            expansion_dict=TestCompete.EXPANSION_PLAN,
+                           lmp_dict=fake_dict,
+                           nov_dict=fake_dict,
+                           ic_dict=fake_dict,
                            nlc_mask=nlc_arr,
+                           zones_arr=fake_flat_array.astype(np.int32),
+                           xcoords=fake_flat_array,
+                           ycoords=fake_flat_array,
                            randomize=False,
                            seed_value=0,
                            verbose=False)
@@ -75,6 +106,9 @@ class TestCompete(unittest.TestCase):
 
         # ensure the expansion plan was updated
         self.assertEqual(TestCompete.COMP_EXP_PLAN, comp.expansion_dict)
+
+        # check sited dict match
+        self.assertEqual(TestCompete.COMP_SITED_DICT, comp.sited_dict)
 
 
 if __name__ == '__main__':

--- a/cerf/utils.py
+++ b/cerf/utils.py
@@ -1,7 +1,7 @@
 
-import rasterio
-
 import numpy as np
+import rasterio
+import xarray as xr
 
 
 def buffer_flat_array(target_index, arr, nrows, ncols, ncells, set_value):
@@ -114,3 +114,23 @@ def array_to_raster(arr, template_raster_file, output_raster_file):
 
         with rasterio.open(output_raster_file, 'w', **metadata) as dest:
             dest.write(arr, 1)
+
+
+def raster_to_coord_arrays(template_raster):
+    """Use the template raster to create two 2D arrays containing the X and Y coordinates of every grid cell.
+
+    :param template_raster:                 Full path with file name and extension to the input raster.
+    :type template_raster:                  str
+
+    :return:                                [0] 2D array of X coordinates
+                                            [1] 2D array of Y coordinates
+
+    """
+
+    # Read the data
+    da = xr.open_rasterio(template_raster)
+
+    # Compute the lon/lat coordinates with rasterio.warp.transform
+    x, y = np.meshgrid(da['x'], da['y'])
+
+    return x, y

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyYAML>=5.3.1
 requests>=2.24.0
 rasterio>=1.1.3
 joblib>=1.0.1
+xarray>=0.15.1


### PR DESCRIPTION
Create CSV output option containing the following fields:

- `state_name`
- `tech_id`
- `xcoord`
- `ycoord`
- `utility_zone`
- `locational_marginal_pricing`
- `net_operational_value`
- `interconnection_cost`
- `net_locational_cost`

More fields can be generated if need be.  All of CERF's internals are available post-run.

Also, fixed but in NLC retrieval for sited capability.
