### PR TITLE
initialize from site coordinates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
       env:
         OS: ${{ matrix.os }}
-        PYTHON: '3.8'
+        PYTHON: '3.9'
 
       steps:
 
@@ -21,7 +21,7 @@ jobs:
         - name: Set up Python
           uses: actions/setup-python@master
           with:
-            python-version: 3.8
+            python-version: 3.9
 
         - name: Install dependencies
           run: |

--- a/cerf/__init__.py
+++ b/cerf/__init__.py
@@ -8,4 +8,4 @@ from .utils import *
 from .install_supplement import install_package_data
 
 
-__version__ = "2.2.1"
+__version__ = "2.3"

--- a/cerf/install_supplement.py
+++ b/cerf/install_supplement.py
@@ -36,7 +36,8 @@ class InstallSupplement:
                          '2.1.0': 'https://zenodo.org/record/5514010/files/cerf_package_data.zip?download=1',
                          '2.1.1': 'https://zenodo.org/record/5514010/files/cerf_package_data.zip?download=1',
                          '2.2.0': 'https://zenodo.org/record/6998151/files/cerf_package_data.zip?download=1',
-                         '2.2.1': 'https://zenodo.org/record/6998151/files/cerf_package_data.zip?download=1'}
+                         '2.2.1': 'https://zenodo.org/record/6998151/files/cerf_package_data.zip?download=1',
+                         '2.3': 'https://zenodo.org/record/6998151/files/cerf_package_data.zip?download=1'}
 
     def __init__(self, data_dir=None):
 

--- a/cerf/stage.py
+++ b/cerf/stage.py
@@ -202,7 +202,9 @@ class Stage:
             logging.info("Initializing previous siting data")
             init_arr, init_df = util.ingest_sited_data(run_year=self.settings_dict['run_year'],
                                                        x_array=self.xcoords,
-                                                       siting_data=self.initialize_site_data)
+                                                       siting_data=self.initialize_site_data,
+                                                       template_raster_file=self.settings_dict.get('region_raster_file'),
+                                                       precision=self.settings_dict.get("lookup_coordinate_precision", 1))
 
             return init_arr, init_df
 

--- a/cerf/utils.py
+++ b/cerf/utils.py
@@ -260,6 +260,34 @@ def raster_to_coord_arrays(template_raster):
     return x, y
 
 
+def genrate_grid_coordinate_lookup(template_raster: str,
+                                   precision: int = 1) -> pd.DataFrame:
+    """Generate a lookup data frame from the input template raster.
+
+    :param template_raster:                 Full path with file name and extension to the input tempate raster file
+    :type template_raster:                  str
+
+    :param precision:                       Desired precision of coordinates to round to
+    :type precision:                        int
+
+    :returns:                               DataFrame of grid index, xcoords, and ycoords in template raster
+    :rtype:                                 pd.DataFrame
+
+    """
+
+    with rasterio.open(template_raster) as src:
+        arr = src.read(1)
+        height, width = arr.shape
+        cols, rows = np.meshgrid(np.arange(width), np.arange(height))
+        xs, ys = rasterio.transform.xy(src.transform, rows, cols)
+
+        # convert to arrays, flatten to 1D and round to tenth
+        xcoords = np.array(xs).flatten().round(precision)
+        ycoords = np.array(ys).flatten().round(precision)
+
+    return pd.DataFrame({"grid_index": range(xcoords.shape[0]), "xcoord": xcoords, "ycoord": ycoords})
+
+
 def ingest_sited_data(run_year, x_array, siting_data):
     """Import sited data containing the locations and additional data to establish an initial suitability condition
     representing power plants and their siting buffer.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ import sys
 import sphinx_rtd_theme
 
 # import cerf
-version = "2.2.1" #str(cerf.__version__)
+version = "2.3" #str(cerf.__version__)
 
 
 sys.path.insert(0, os.path.abspath('../../'))
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 # -- Project information -----------------------------------------------------
 
 project = 'cerf'
-copyright = '2021-2022, Battelle Memorial Institute'
+copyright = '2021-current, Battelle Memorial Institute'
 author = 'Chris R. Vernon'
 
 # The full version, including alpha/beta/rc tags

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description='An open-source geospatial Python package for assessing and analyzing future electricity technology capacity expansion feasibility',
     long_description=readme(),
     long_description_content_type="text/markdown",
-    python_requires='>=3.7.*, <4',
+    python_requires='>=3.9.*, <4',
     include_package_data=True,
     install_requires=[
         'numpy>=1.19.4',


### PR DESCRIPTION
Add feature to initialize power plant locations from coordinates instead of index which was only available when inheriting previous cerf output.

Also updated the minimum Python version for the package and actions to 3.9 per dependency requirement.