### PR TITLE
v2.3.2

### DIFF
--- a/cerf/__init__.py
+++ b/cerf/__init__.py
@@ -8,4 +8,4 @@ from .utils import *
 from .install_supplement import install_package_data
 
 
-__version__ = "2.3.1"
+__version__ = "2.3.2"

--- a/cerf/install_supplement.py
+++ b/cerf/install_supplement.py
@@ -38,7 +38,8 @@ class InstallSupplement:
                          '2.2.0': 'https://zenodo.org/record/6998151/files/cerf_package_data.zip?download=1',
                          '2.2.1': 'https://zenodo.org/record/6998151/files/cerf_package_data.zip?download=1',
                          '2.3': 'https://zenodo.org/record/6998151/files/cerf_package_data.zip?download=1',
-                         '2.3.1': 'https://zenodo.org/record/6998151/files/cerf_package_data.zip?download=1'}
+                         '2.3.1': 'https://zenodo.org/record/6998151/files/cerf_package_data.zip?download=1',
+                         '2.3.2': 'https://zenodo.org/record/6998151/files/cerf_package_data.zip?download=1'}
 
     def __init__(self, data_dir=None):
 

--- a/cerf/utils.py
+++ b/cerf/utils.py
@@ -1,4 +1,4 @@
-
+import os
 import logging
 import tempfile
 
@@ -331,14 +331,17 @@ def ingest_sited_data(run_year,
         # update data type
         metadata.update(dtype=np.uint32)
 
-    with tempfile.NamedTemporaryFile() as tmpfile:
+    with tempfile.TemporaryDirectory() as tempdir:
+
+        # construct temporary raster file name
+        out_temp_rast = os.path.join(tempdir, "cerf_temp_raster.tif")
 
         # write array as spatial in a temp file
-        with rasterio.open(tmpfile, "w", **metadata) as dest:
+        with rasterio.open(out_temp_rast, "w", **metadata) as dest:
             dest.write(index_arr, 1)
 
         # read temp file to use for grid search
-        with rasterio.open(tmpfile.name) as idx:
+        with rasterio.open(out_temp_rast) as idx:
             index_generator = idx.sample(df_active[["xcoord", "ycoord"]].values)
             located_index_list = [i[0] for i in index_generator]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ import sys
 import sphinx_rtd_theme
 
 # import cerf
-version = "2.3.1" #str(cerf.__version__)
+version = "2.3.2" #str(cerf.__version__)
 
 
 sys.path.insert(0, os.path.abspath('../../'))


### PR DESCRIPTION
**CERF v2.3.2**

- Use tempdir instead of named temp file for compatability with Windows paths
